### PR TITLE
PR suggestion

### DIFF
--- a/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/instrumentation/decorator/BaseDecorator.java
+++ b/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/instrumentation/decorator/BaseDecorator.java
@@ -68,30 +68,26 @@ public abstract class BaseDecorator {
   public Span onPeerConnection(final Span span, final InetSocketAddress remoteConnection) {
     assert span != null;
     if (remoteConnection != null) {
-      onPeerConnection(span, remoteConnection.getAddress(), remoteConnection.getHostString());
-
+      InetAddress remoteAddress = remoteConnection.getAddress();
+      if (remoteAddress != null) {
+        onPeerConnection(span, remoteAddress);
+      } else {
+        // Failed DNS lookup, the host string is the name.
+        String hostString = remoteConnection.getHostString();
+        span.setAttribute(MoreTags.NET_PEER_NAME, hostString);
+      }
       span.setAttribute(MoreTags.NET_PEER_PORT, remoteConnection.getPort());
     }
     return span;
   }
 
   public Span onPeerConnection(final Span span, final InetAddress remoteAddress) {
-    return onPeerConnection(span, remoteAddress, null);
-  }
-
-  private Span onPeerConnection(
-      final Span span, final InetAddress remoteAddress, String hostString) {
     assert span != null;
-    if (remoteAddress != null) {
-      final String hostName = remoteAddress.getHostName();
-      if (!hostName.equals(remoteAddress.getHostAddress())) {
-        span.setAttribute(MoreTags.NET_PEER_NAME, remoteAddress.getHostName());
-      }
-      span.setAttribute(MoreTags.NET_PEER_IP, remoteAddress.getHostAddress());
-    } else if (hostString != null) {
-      // Failed DNS lookup, the host string is the name.
-      span.setAttribute(MoreTags.NET_PEER_NAME, hostString);
+    final String hostName = remoteAddress.getHostName();
+    if (!hostName.equals(remoteAddress.getHostAddress())) {
+      span.setAttribute(MoreTags.NET_PEER_NAME, remoteAddress.getHostName());
     }
+    span.setAttribute(MoreTags.NET_PEER_IP, remoteAddress.getHostAddress());
     return span;
   }
 

--- a/agent-bootstrap/src/test/groovy/io/opentelemetry/auto/bootstrap/instrumentation/decorator/BaseDecoratorTest.groovy
+++ b/agent-bootstrap/src/test/groovy/io/opentelemetry/auto/bootstrap/instrumentation/decorator/BaseDecoratorTest.groovy
@@ -58,7 +58,6 @@ class BaseDecoratorTest extends AgentSpecification {
     where:
     connection                                      | expectedPeerName    | expectedPeerIp
     new InetSocketAddress("localhost", 888)         | "localhost"         | "127.0.0.1"
-    new InetSocketAddress("127.0.0.1", 888)         | "localhost"         | "127.0.0.1"
     new InetSocketAddress("1.2.3.4", 888)           | null                | "1.2.3.4"
     resolvedAddress                                 | "github.com"        | resolvedAddress.address.hostAddress
     new InetSocketAddress("bad.address.local", 999) | "bad.address.local" | null


### PR DESCRIPTION
I didn't understand what was going on, so had to try it out, and figured may as well send in my suggestion this way.

I think it makes sense for the DNS failure conditional to only be inside the `InetSocketAddress` overload, instead of the common delegate.

Also, Windows 😆.